### PR TITLE
Update ORCv1.md

### DIFF
--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1125,7 +1125,7 @@ DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
 
 Timestamp records times down to nanoseconds as a PRESENT stream that
 records non-null values, a DATA stream that records the number of
-seconds after 1 January 2015, and a SECONDARY stream that records the
+seconds after 1 January 1970, and a SECONDARY stream that records the
 number of nanoseconds.
 
 Because the number of nanoseconds often has a large number of trailing


### PR DESCRIPTION

### What changes were proposed in this pull request?
Change to docs text.

### Why are the changes needed?
Docs do not match code comments.
As per comment in Vector.hh:
The timestamps are stored split into the time_t value (seconds since 1 Jan 1970 00:00:00)
